### PR TITLE
Dynamic determination of Controller and Cinder Endpoint IPs

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -15,7 +15,9 @@
 
 export DEBIAN_FRONTEND=noninteractive
 
-export CONTROLLER_HOST=172.16.0.200
+#export CONTROLLER_HOST=172.16.0.200
+#Dynamically determine first three octets if user specifies alternative IP ranges.  Fourth octet still hardcoded
+export CONTROLLER_HOST=$(ifconfig eth1 | awk '/inet addr/ {split ($2,A,":"); print A[2]}' | sed 's/\.[0-9]*$/.200/')
 export GLANCE_HOST=${CONTROLLER_HOST}
 export MYSQL_HOST=${CONTROLLER_HOST}
 export KEYSTONE_ENDPOINT=${CONTROLLER_HOST}

--- a/controller-gre.sh
+++ b/controller-gre.sh
@@ -163,7 +163,9 @@ keystone endpoint-create --region RegionOne --service_id $KEYSTONE_SERVICE_ID --
 
 # Cinder Block Storage Service
 CINDER_SERVICE_ID=$(keystone service-list | awk '/\ volume\ / {print $2}')
-CINDER_ENDPOINT="172.16.0.211"
+#CINDER_ENDPOINT="172.16.0.211"
+#Dynamically determine first three octets if user specifies alternative IP ranges.  Fourth octet still hardcoded
+CINDER_ENDPOINT=$(ifconfig eth1 | awk '/inet addr/ {split ($2,A,":"); print A[2]}' | sed 's/\.[0-9]*$/.211/')
 PUBLIC="http://$CINDER_ENDPOINT:8776/v1/%(tenant_id)s"
 ADMIN=$PUBLIC
 INTERNAL=$PUBLIC

--- a/controller-vlan.sh
+++ b/controller-vlan.sh
@@ -159,7 +159,9 @@ keystone endpoint-create --region RegionOne --service_id $KEYSTONE_SERVICE_ID --
 
 # Cinder Block Storage Service
 CINDER_SERVICE_ID=$(keystone service-list | awk '/\ volume\ / {print $2}')
-CINDER_ENDPOINT="172.16.0.211"
+#CINDER_ENDPOINT="172.16.0.211"
+#Dynamically determine first three octets if user specifies alternative IP ranges.  Fourth octet still hardcoded
+CINDER_ENDPOINT=$(ifconfig eth1 | awk '/inet addr/ {split ($2,A,":"); print A[2]}' | sed 's/\.[0-9]*$/.211/')
 PUBLIC="http://$CINDER_ENDPOINT:8776/v1/%(tenant_id)s"
 ADMIN=$PUBLIC
 INTERNAL=$PUBLIC


### PR DESCRIPTION
During a recent lab session, I needed to change the IPs.  These two items appeared to be the only hardcoded IP values left (aside from the fourth octets).

Hopefully, these changes can help users have a little more flexibility with configuring the environment.
