### PR TITLE
Changed branch in README.md from icehouse to juno

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ vagrant plugin install vagrant-cachier
 ```bash
 git clone https://github.com/OpenStackCookbook/OpenStackCookbook.git
 cd OpenStackCookbook
-git checkout icehouse
+git checkout juno
 vagrant up
 ```
 ### Using OpenStack


### PR DESCRIPTION
The README.md promotes the new Juno compatibility and then checks-out icehouse in the example code snippet.

Also eventually needs to be fixed in master.