### PR TITLE
Added VirtualBox provider config to override Fusion

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,9 @@
 # enable compute2
 # configure compute and compute2 for dvr
 
+# Uncomment the next line to force use of VirtualBox provider when Fusion provider is present
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
+
 nodes = {
 #    'openldap'  => [1, 199],
     'controller'  => [1, 200],


### PR DESCRIPTION
Some cases where Fusion provider is present can cause Vagrant to use
the wrong provider, or some may want to force VIrtualBox over Fusion.