### PR TITLE
copy openrc file to local instance filesystem

### DIFF
--- a/cinder.sh
+++ b/cinder.sh
@@ -92,3 +92,6 @@ sudo stop rsyslog
 sudo cp /vagrant/rsyslog.conf /etc/rsyslog.conf
 sudo echo "*.*         @@controller:5140" >> /etc/rsyslog.d/50-default.conf
 sudo service rsyslog restart
+
+# Copy openrc file to local instance vagrant root folder in case of loss of file share
+sudo cp /vagrant/openrc /home/vagrant 

--- a/compute.sh
+++ b/compute.sh
@@ -389,3 +389,6 @@ sudo stop rsyslog
 sudo cp /vagrant/rsyslog.conf /etc/rsyslog.conf
 sudo echo "*.*         @@controller:5140" >> /etc/rsyslog.d/50-default.conf
 sudo service rsyslog restart
+
+# Copy openrc file to local instance vagrant root folder in case of loss of file share
+sudo cp /vagrant/openrc /home/vagrant 

--- a/controller.sh
+++ b/controller.sh
@@ -1434,6 +1434,9 @@ export OS_KEY=/vagrant/cakey.pem
 export OS_CACERT=/vagrant/ca.pem
 EOF
 
+# Copy openrc file to local instance vagrant root folder in case of loss of file share
+sudo cp /vagrant/openrc /home/vagrant 
+
 # Hack: restart neutron again...
 service neutron-server restart
 

--- a/network.sh
+++ b/network.sh
@@ -228,3 +228,6 @@ sudo stop rsyslog
 sudo cp /vagrant/rsyslog.conf /etc/rsyslog.conf
 sudo echo "*.*         @@controller:5140" >> /etc/rsyslog.d/50-default.conf
 sudo service rsyslog restart
+
+# Copy openrc file to local instance vagrant root folder in case of loss of file share
+sudo cp /vagrant/openrc /home/vagrant 

--- a/swift.sh
+++ b/swift.sh
@@ -389,3 +389,6 @@ swift_restart(){
 swift_install
 swift_configure
 swift_restart
+
+# Copy openrc file to local instance vagrant root folder in case of loss of file share
+sudo cp /vagrant/openrc /home/vagrant 

--- a/swift2.sh
+++ b/swift2.sh
@@ -391,3 +391,6 @@ swift_restart(){
 swift_install
 swift_configure
 swift_restart
+
+# Copy openrc file to local instance vagrant root folder in case of loss of file share
+sudo cp /vagrant/openrc /home/vagrant 


### PR DESCRIPTION
Occasionally vagrant shares aren’t available and this allows locally
sourcing the file rather than typing it in manually.